### PR TITLE
Add support to SPI interface of MPU-9250

### DIFF
--- a/nuttx/drivers/sensors/inv_mpu_spi.c
+++ b/nuttx/drivers/sensors/inv_mpu_spi.c
@@ -120,7 +120,12 @@ static inline int mpu_spi_trans(FAR struct mpu_spi_low_s *priv, bool read,
   /* Select the MPU9250 */
 
   SPI_SELECT(priv->spi, SPIDEV_ACCELEROMETER, true);
-  
+ 
+  /* Read operation needs MSB = 1 */
+
+  if ( read )
+    reg_off |= 0x80;
+
   /* Send register to read and get the next byte */
 
   (void)SPI_SEND(priv->spi, reg_off);

--- a/nuttx/drivers/sensors/inv_mpu_spi.c
+++ b/nuttx/drivers/sensors/inv_mpu_spi.c
@@ -180,9 +180,9 @@ static int akm_spi_write(FAR struct mpu_low_s* low, int reg_off,
   struct mpu_spi_low_s* priv = (struct mpu_spi_low_s*)low;
 
   /* TODO use internal I2C MASTER of MPU */
-#warning 'not implemented"
+#warning "not implemented"
 
-  return -1;
+  return 0;
 }
 
 /* AKM read access */
@@ -193,9 +193,9 @@ static int akm_spi_read(FAR struct mpu_low_s* low, int reg_off,
   struct mpu_spi_low_s* priv = (struct mpu_spi_low_s*)low;
 
   /* TODO use internal I2C MASTER of MPU */
-#warning 'not implemented"
+#warning "not implemented"
 
-  return -1;
+  return 0;
 }
 
 

--- a/nuttx/drivers/sensors/inv_mpu_spi.c
+++ b/nuttx/drivers/sensors/inv_mpu_spi.c
@@ -129,6 +129,10 @@ static inline int mpu_spi_trans(FAR struct mpu_spi_low_s *priv, bool read,
   /* Send register to read and get the next byte */
 
   (void)SPI_SEND(priv->spi, reg_off);
+
+  /* Delay about 5ms */
+  up_mdelay(5);
+
   if ( read )
   {
       SPI_RECVBLOCK(priv->spi, buf, size);

--- a/nuttx/include/nuttx/sensors/inv_mpu.h
+++ b/nuttx/include/nuttx/sensors/inv_mpu.h
@@ -293,6 +293,9 @@ extern "C" {
 /* low level function */
 
 #ifdef CONFIG_INVENSENSE_SPI
+
+#define MPU9250_SPI_MAXFREQUENCY 1000000
+
 struct spi_dev_s; /* See nuttx/spi/spi.h */
 struct mpu_low_s* mpu_low_spi_init(int devno, int akm_addr, 
                                    FAR struct spi_dev_s* spi);


### PR DESCRIPTION
These patches enable SPI interface communication with MPU-9250.
TODO: Add support to AK8963 communication over MPU-9250's I2C interface.